### PR TITLE
Crash fixes

### DIFF
--- a/src/Band.c
+++ b/src/Band.c
@@ -52,7 +52,7 @@ DmDlsInstrument* DmInstrument_getDlsInstrument(DmInstrument* slf) {
 	uint32_t patch = slf->patch & 0xFFU;
 
 	DmDlsInstrument* ins = NULL;
-	for (long long i = slf->dls->instrument_count; i >= 0; --i) {
+	for (long long i = slf->dls->instrument_count-1; i >= 0; --i) {
 		ins = &slf->dls->instruments[i];
 
 		// If it's the correct instrument, return it.

--- a/src/Riff.c
+++ b/src/Riff.c
@@ -40,6 +40,11 @@ bool DmRiff_readChunk(DmRiff* slf, DmRiff* out) {
 		return false;
 	}
 
+	// Cover odd case where ISFT reads to end of file,
+	// but chunk reports over-read
+	if (slf->pos > slf->len) {
+		return false;
+	}
 	size_t remaining = slf->len - slf->pos;
 	if (remaining < sizeof(uint32_t) * 2) {
 		return false;

--- a/src/Synth.c
+++ b/src/Synth.c
@@ -100,7 +100,9 @@ static DmResult DmSynth_updateFonts(DmSynth* slf, DmBand* band) {
 				// to bring them back into scope.
 				size_t offset = slf->fonts.data - old;
 				for (size_t r = 0; r < slf->channels_len; ++r) {
-					slf->channels[r].font += offset;
+					if (slf->channels[r].font != NULL) {
+						slf->channels[r].font += offset;
+					}
 				}
 			} else {
 				rv = DmSynthFontArray_add(&slf->fonts, new_fnt);


### PR DESCRIPTION
* Fix DmInstrument_getDlsInstrument overflowing dls->instruments
* Work-around crash where an ISFT read can end at end-of-file, but appear to be an over-read in the chunk
* Fix crash with DmSynth_updateFonts that can occur if you call DmPerformance_playSegment while a segment is playing

I'm not too happy with the work-around, but I don't have a lot of knowledge with this codebase. :sweat_smile: 

With the first two fix/work arounds I can get sgt files from No One Lives Forever 1 playing albiet with some incorrect notes, and instruments.